### PR TITLE
Update Honda Odyssey generations: Added Wikipedia references

### DIFF
--- a/generations.yaml
+++ b/generations.yaml
@@ -1,5 +1,6 @@
 references:
   - "https://en.wikipedia.org/wiki/Honda_Odyssey_(North_America)"
+  - "https://en.wikipedia.org/wiki/Honda_Odyssey_(minivan)"
 
 generations:
   - name: "First Generation"


### PR DESCRIPTION
- Verified all 5 generations match official production dates from Wikipedia
- First Generation: 1994-1998 (compact, hinged doors)
- Second Generation: 1999-2004 (full-size minivan with sliding doors)
- Third Generation: 2005-2010 (ACE body structure, VCM engine)
- Fourth Generation: 2011-2017 (Wide Mode seats, HondaVAC)
- Fifth Generation: 2018-present (Magic Slide seats, Honda Sensing standard)
- Added reference URLs from Wikipedia articles
